### PR TITLE
Task API fix, add Popup if command fails

### DIFF
--- a/theia-readonly/package.json
+++ b/theia-readonly/package.json
@@ -6,7 +6,7 @@
     "che"
   ],
   "description": "Eclipse Che (Theia) - ReadOnly Extension. This extension adds support to use ReadOnly mode of editor for files that are supposed to be not edited by someone",
-  "version": "0.0.2",
+  "version": "0.3.19.2",
   "files": [
     "lib",
     "src"

--- a/theia-run/package.json
+++ b/theia-run/package.json
@@ -7,7 +7,7 @@
     "che"
   ],
   "description": "Eclipse Che (Theia) - Run Extension. This extension adds support to Run any Task just with One Click!",
-  "version": "0.0.2",
+  "version": "0.3.19.2",
   "files": [
     "lib",
     "src"
@@ -15,7 +15,8 @@
   "dependencies": {
     "@theia/core": "latest",
     "@theia/task": "^0.3.19",
-    "@theia/filesystem": "latest"
+    "@theia/filesystem": "latest",
+    "@theia/workspace": "latest"
   },
   "devDependencies": {
     "rimraf": "latest",


### PR DESCRIPTION
Theia Task changed upstream api, instead of commands it require now
workspacepath.
Version numbers are in sync with Upstream API with following convention.
'Upstreamversion'.'HackerRank version'
eg: '0.3.19'.'2'

Add msg popup if command fails

Signed-off-by: aaqaishtyaq <aaqaishtyaq@gmail.com>